### PR TITLE
Cm post target increase

### DIFF
--- a/main.gms
+++ b/main.gms
@@ -1086,12 +1086,12 @@ parameter
 *' * (any other number) limit of gas demand from 2025 on in Germany in EJ/yr
 *'
 parameter
-  c_SlackMultiplier   "Muliplicative factor to up/downscale the slack size for v_changeProdStartyearSlack"
+  c_SlackMultiplier   "Multiplicative factor to up/downscale the slack size for v_changeProdStartyearSlack"
 ;
   c_SlackMultiplier = 1; !! def 1
 *'
 parameter
-  c_changeProdCost   "Muliplicative factor to up/downscale the costs for vm_changeProdStartyearCost"
+  c_changeProdCost   "Multiplicative factor to up/downscale the costs for vm_changeProdStartyearCost"
 ;
   c_changeProdCost = 5; !! def 5
 *'

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -275,7 +275,7 @@ loop(ext_regi$regiEmiMktTarget(ext_regi),
             loop(ttot3$(ttot3.val eq p47_nextConvergencePeriod(ext_regi)), !! ttot2 = beginning of slope; ttot3 = end of slope
               pm_taxemiMkt(ttot3,regi,emiMkt) = p47_averagetaxemiMkt(ttot3,regi);
               pm_taxemiMkt(t,regi,emiMkt)$((t.val gt ttot2.val) AND (t.val lt ttot3.val)) = pm_taxemiMkt(ttot2,regi,emiMkt) + ((pm_taxemiMkt(ttot3,regi,emiMkt) - pm_taxemiMkt(ttot2,regi,emiMkt))/(ttot3.val-ttot2.val))*(t.val-ttot2.val); !! price in between current target year and next target year
-              pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot3.val) = pm_taxemiMkt(ttot3,regi,emiMkt) + (cm_postTargetIncrease*sm_DptCO2_2_TDpGtC)*(t.val-ttot3.val); !! price after next target year
+***              pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot3.val) = pm_taxemiMkt(ttot3,regi,emiMkt) + (cm_postTargetIncrease*sm_DptCO2_2_TDpGtC)*(t.val-ttot3.val); !! price after next target year -- this line needs to be reinstated, covering the options that cm_postTargetIncrease is off, NPi or NDC
             );
           else
 ***         behavior after terminal year: fixed price (cm_postTargetIncrease=off or 0), global convergence (cm_postTargetIncrease=NPi or NDC), or fixed year increase (cm_postTargetIncrease €/tCO2 increase per year)

--- a/modules/47_regipol/regiCarbonPrice/postsolve.gms
+++ b/modules/47_regipol/regiCarbonPrice/postsolve.gms
@@ -283,20 +283,20 @@ $ifthen %cm_postTargetIncrease% == "off"
             pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val) = pm_taxemiMkt(ttot2,regi,emiMkt);
 $elseif %cm_postTargetIncrease% == "NPi"
 *** convergence scheme post ttot2.val: exponential increase of 5$ in 2020 with 1.25% AND regional convergence until 2100
-            pm_taxemiMkr(t,regi,emiMkt)$(t.val gt ttot2.val)
+            pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val)
               = (
-                  sum(ttot3, pm_taxCO2eq(ttot3,regi)$(ttot3.val eq ttot2.val - 5)) * max(2100 - t.val,  0)
-                  + 5 * sm_DptCO2_2_TDpGtC * 1.0125**(t.val-2020)                  * min(t.val - 2020, 80)
+                  sum(ttot3, pm_taxemiMkt(ttot3,regi,emiMkt)$(ttot3.val eq ttot2.val)) * max(2100 - t.val,  0)
+                  + 5 * sm_DptCO2_2_TDpGtC * 1.0125**(t.val-2020)                      * min(t.val - 2020, 80)
                 )/80;
 $elseif %cm_postTargetIncrease% == "NDC"
 *** convergence scheme post ttot2.val: exponential increase of 30$ in 2030 AND regional convergence until 2100, both increasing with 1.25% per year
-            pm_taxemiMkr(t,regi,emiMkt)$(t.val gt ttot2.val)
+            pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val)
               = (
-                  sum(ttot3, pm_taxCO2eq(ttot3,regi)$(ttot3.val eq ttot2.val - 5)) * 1.0125**(t.val-ttot2.val) * max(2100 - t.val, 0)
-                  + 30 * sm_DptCO2_2_TDpGtC * 1.0125**(t.val-2030)                                             * min(t.val - 2030, 70)
-                )/70;
+                  sum(ttot3, pm_taxemiMkt(ttot3,regi,emiMkt)$(ttot3.val eq ttot2.val)) * 1.0125**(t.val-ttot2.val) * max(2100 - t.val, 0)
+                  + 30 * sm_DptCO2_2_TDpGtC * 1.0125**(t.val-2030)                                                 * min(t.val - ttot2.val, 2100 - ttot2.val)
+                )/(2100 - ttot2.val);
 *** as a minimum, have linear price increase starting from 1$ in 2030
-            pm_taxemiMkr(t,regi,emiMkr)$(t.val gt ttot2.val) = max(pm_taxemiMkr(t,regi,emiMkr), 1 * sm_DptCO2_2_TDpGtC * (1+(t.val-2030)*9/7));
+            pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val) = max(pm_taxemiMkt(t,regi,emiMkt), 1 * sm_DptCO2_2_TDpGtC * (1+(t.val-2030)*9/7));
 $else
             pm_taxemiMkt(t,regi,emiMkt)$(t.val gt ttot2.val) = pm_taxemiMkt(ttot2,regi,emiMkt) + (%cm_postTargetIncrease%*sm_DptCO2_2_TDpGtC)*(t.val-ttot2.val);
 $endif


### PR DESCRIPTION
## Purpose of this PR

- always replace pm_taxCO2eq by pm_taxemiMkt
- start NDC convergence not in 2030, but in ttot2 (which should be 2030 in most cases)
- fix some typos

FYI @Renato-Rodrigues (can't assign reviewers…)